### PR TITLE
setup the libraries install commad

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # machine_learning_project
 
+>FileName: It's called `module`
+>FolderName: It's called `package`
+
 Following things are required.
 1. GIT-HUB
 2. Docker, Docker-HUB
@@ -58,7 +61,7 @@ To stop docker containers
 docker stop <container_id>
 ```
 
-
+> Note: following command may rise some error in windos. intead that command you can use this -> ` pip install -r requirements.txt ` 
 TO install all libraries which mentioned in requirements.txt
 ```
 python setup.py install

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ gunicorn
 sklearn
 pandas
 numpy
+# -e .  # This is for our own package like here is "housing", We need to install these too. .(period) means current directory, it work in window only, not working in ubantu with custom install command. -e . is require in requirements.txt file, not in setup.py package.

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 from typing import List
 
 # Declairing variables for setup function
@@ -6,7 +6,6 @@ PROJECT_NAME="housing-predictor"
 VERSION="0.0.1"
 AUTHOR="Rushikesh"
 DESCRIPTION="This first project in ml"
-PACAKAGES=["housing"]
 REQUIREMENT_FILE_NAME="requirements.txt"
 
 
@@ -18,6 +17,7 @@ def get_requirements_list()-> List[str]:
     return This function going to return a list which contain name of libraries mention in requirements.txt
     '''
     with open(REQUIREMENT_FILE_NAME) as requirement_file:
+        # return requirement_file.readlines().remove("-e .") for windows
         return requirement_file.readlines()
 
 setup(
@@ -25,6 +25,6 @@ setup(
     version=VERSION,
     author=AUTHOR,
     description=DESCRIPTION,
-    packages=PACAKAGES,
+    packages=find_packages(), # ["housing"] : it return folder name all that folder name which contains __init__.py file
     install_requires=get_requirements_list()
 )


### PR DESCRIPTION
1. Setup the command `python setup.py install` for ubantu.
2. Above the command may not work on windows for that you have to use 'pip install -r requirements.txt` and add `-e .` in requirements.txt.
3. -e . means current packages like housing here. `python setup.py install` this command cover 2 tip in ubantu.
